### PR TITLE
Auto rollback migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /doc
 /tmp
 erl_crash.dump
+
+.idea/
+*.iml

--- a/lib/ecto/migration/runner.ex
+++ b/lib/ecto/migration/runner.ex
@@ -12,6 +12,7 @@ defmodule Ecto.Migration.Runner do
   @doc """
   Runs the given migration.
   """
+  #args: repo, config, version, module, :forward, :up, :up, opts
   def run(repo, config, version, module, direction, operation, migrator_direction, opts) do
     level = Keyword.get(opts, :log, :info)
     sql = Keyword.get(opts, :log_sql, false)

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -9,6 +9,7 @@ defmodule Ecto.Migration.SchemaMigration do
   @primary_key false
   schema "schema_migrations" do
     field :version, :integer
+    field :migration_script, :string
     timestamps updated_at: false
   end
 
@@ -24,6 +25,7 @@ defmodule Ecto.Migration.SchemaMigration do
 
     commands = [
       {:add, :version, :bigint, primary_key: true},
+      {:add, :migration_script, :text, []},
       {:add, :inserted_at, :naive_datetime, []}
     ]
 
@@ -33,18 +35,18 @@ defmodule Ecto.Migration.SchemaMigration do
 
   def versions(repo, config, prefix) do
     {repo, source} = get_repo_and_source(repo, config)
-    {repo, from(m in source, select: type(m.version, :integer)), [prefix: prefix] ++ @opts}
+    {repo, from(m in source, select: [type(m.version, :integer), type(m.migration_script, :string)]), [prefix: prefix] ++ @opts}
   end
 
-  def up(repo, config, version, prefix) do
+  def up(repo, config, version, migration_script, prefix) do
     {repo, source} = get_repo_and_source(repo, config)
 
-    %__MODULE__{version: version}
+    %__MODULE__{version: version, migration_script: migration_script}
     |> Ecto.put_meta(source: source)
     |> repo.insert([prefix: prefix] ++ @opts)
   end
 
-  def down(repo, config, version, prefix) do
+  def down(repo, config, version, _migration_script, prefix) do
     {repo, source} = get_repo_and_source(repo, config)
 
     from(m in source, where: m.version == type(^version, :integer))

--- a/lib/ecto/migration/schema_migration.ex
+++ b/lib/ecto/migration/schema_migration.ex
@@ -33,6 +33,20 @@ defmodule Ecto.Migration.SchemaMigration do
     repo.__adapter__().execute_ddl(meta, {:create_if_not_exists, table, commands}, @opts)
   end
 
+  def ensure_schema_migrations_table_updated!(repo, config, opts) do
+    {repo, source} = get_repo_and_source(repo, config)
+    table_name = String.to_atom(source)
+    table = %Ecto.Migration.Table{name: table_name, prefix: opts[:prefix]}
+    meta = Ecto.Adapter.lookup_meta(repo.get_dynamic_repo())
+
+    commands = [
+      {:add_if_not_exists, :migration_script, :text, []}
+    ]
+
+    # DDL queries do not log, so we do not need to pass log: false here.
+    repo.__adapter__().execute_ddl(meta, {:alter, table, commands}, @opts)
+  end
+
   def versions(repo, config, prefix) do
     {repo, source} = get_repo_and_source(repo, config)
     {repo, from(m in source, select: [type(m.version, :integer), type(m.migration_script, :string)]), [prefix: prefix] ++ @opts}

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -382,14 +382,14 @@ defmodule Ecto.Migrator do
   """
   @spec run(Ecto.Repo.t, String.t | [String.t] | [{integer, module}], atom, Keyword.t) :: [integer]
   def run(repo, migration_source, _direction, opts = [smart: true]) do
-    smart_migrations_confirm(repo)
-    |> case  do
-       :ok ->
-          run_smart(repo, migration_source, opts)
-       _ ->
-          #noop if user enters anything other than 'y'
-          :ok
-     end
+    with true <- Mix.env() == :dev,
+        :ok <- smart_migrations_confirm(repo)
+    do
+      run_smart(repo, migration_source, opts)
+    else
+      #noop if not in dev or if user enters anything other than 'y'
+      output -> :ok
+    end
   end
 
   def run(repo, migration_source, direction, opts) do

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -216,7 +216,7 @@ defmodule Ecto.Migrator do
       if version in versions do
         :already_up
       else
-        result = do_up(repo, config, version, module, opts)
+        result = do_up(repo, config, version, "", module, opts)
 
         if version != Enum.max([version | versions]) do
           latest = Enum.max(versions)
@@ -245,8 +245,10 @@ defmodule Ecto.Migrator do
     end
   end
 
-  defp do_up(repo, config, version, module, opts) do
-    async_migrate_maybe_in_transaction(repo, config, version, module, :up, opts, fn ->
+  defp do_up(repo, config, version, migration_script, module, opts) do
+    async_migrate_maybe_in_transaction(repo, config, version, migration_script, module, :up, opts, fn ->
+    #TODO https://stackoverflow.com/a/13237894, Code.eval for runnin it, should check for down as well
+    #this should maybe be earlier though, before we start running the ups
       attempt(repo, config, version, module, :forward, :up, :up, opts)
         || attempt(repo, config, version, module, :forward, :change, :up, opts)
         || {:error, Ecto.MigrationError.exception(
@@ -272,15 +274,15 @@ defmodule Ecto.Migrator do
   def down(repo, version, module, opts \\ []) do
     conditional_lock_for_migrations module, version, repo, opts, fn config, versions ->
       if version in versions do
-        do_down(repo, config, version, module, opts)
+        do_down(repo, config, version, "", module, opts)
       else
         :already_down
       end
     end
   end
 
-  defp do_down(repo, config, version, module, opts) do
-    async_migrate_maybe_in_transaction(repo, config, version, module, :down, opts, fn ->
+  defp do_down(repo, config, version, migration_script, module, opts) do
+    async_migrate_maybe_in_transaction(repo, config, version, migration_script, module, :down, opts, fn ->
       attempt(repo, config, version, module, :forward, :down, :down, opts)
         || attempt(repo, config, version, module, :backward, :change, :down, opts)
         || {:error, Ecto.MigrationError.exception(
@@ -288,12 +290,12 @@ defmodule Ecto.Migrator do
     end)
   end
 
-  defp async_migrate_maybe_in_transaction(repo, config, version, module, direction, opts, fun) do
+  defp async_migrate_maybe_in_transaction(repo, config, version, migration_script, module, direction, opts, fun) do
     dynamic_repo = repo.get_dynamic_repo()
 
     fun_with_status = fn ->
       result = fun.()
-      apply(SchemaMigration, direction, [repo, config, version, opts[:prefix]])
+      apply(SchemaMigration, direction, [repo, config, version, migration_script, opts[:prefix]])
       result
     end
 
@@ -381,6 +383,36 @@ defmodule Ecto.Migrator do
 
   """
   @spec run(Ecto.Repo.t, String.t | [String.t] | [{integer, module}], atom, Keyword.t) :: [integer]
+  def run(repo, migration_source, _direction, opts = [smart: true]) do
+    migration_source = List.wrap(migration_source)
+
+    pending =
+      lock_for_migrations true, repo, opts, fn _config, versions ->
+        versions_with_hash =
+          versions
+          |> Enum.map(fn [version | _] -> version end)
+          |> pending_in_direction(migration_source, :smart)
+          |> Enum.map(&load_migration!/1)
+          |> Enum.map(&hash_migration_source/1)
+          |> Enum.map(fn {version, _, hash} -> {version, hash} end)
+          |> Enum.into(%{})
+
+        versions
+        |> Enum.map(&load_migration!/1)
+        |> Enum.map(&hash_migration_source/1)
+        |> Enum.sort(fn {left, _, _}, {right, _, _} -> left < right end)
+        |> needs_down?(versions_with_hash, :no_change)
+        |> Enum.reverse
+      end
+
+    # The lock above already created the table, so we can now skip it.
+    opts = Keyword.put(opts, :skip_table_creation, true)
+
+    ensure_no_duplication!(pending)
+    migrate(pending |> IO.inspect(label: "pending"), :smart_down, repo, opts)
+    run(repo, migration_source, :up, [all: true])
+  end
+
   def run(repo, migration_source, direction, opts) do
     migration_source = List.wrap(migration_source)
 
@@ -388,11 +420,11 @@ defmodule Ecto.Migrator do
       lock_for_migrations true, repo, opts, fn _config, versions ->
         cond do
           opts[:all] ->
-            pending_all(versions, migration_source, direction)
+            pending_all(versions |> Enum.map(&List.first(&1)), migration_source, direction)
           to = opts[:to] ->
-            pending_to(versions, migration_source, direction, to)
+            pending_to(versions |> Enum.map(&List.first(&1)), migration_source, direction, to)
           step = opts[:step] ->
-            pending_step(versions, migration_source, direction, step)
+            pending_step(versions |> Enum.map(&List.first(&1)), migration_source, direction, step)
           true ->
             {:error, ArgumentError.exception("expected one of :all, :to, or :step strategies")}
         end
@@ -429,23 +461,97 @@ defmodule Ecto.Migrator do
 
     repo
     |> migrated_versions(opts)
-    |> collect_migrations(directories)
+    |> collect_migrations(directories, opts)
     |> Enum.sort_by(fn {_, version, _} -> version end)
   end
 
-  defp collect_migrations(versions, migration_source) do
+  defp hash_migration_source([]), do: []
+
+  defp hash_migration_source([version, migration_source]) do
+    {version, migration_source, hash_migration_source(migration_source)}
+  end
+
+  defp hash_migration_source({version, module, migration_source}) do
+    {version, module, hash_migration_source(migration_source)}
+  end
+
+  defp hash_migration_source(migration_source) when is_binary(migration_source) do
+    :crypto.hash(:sha256, migration_source)
+    |> Base.encode16()
+    |> String.downcase()
+  end
+
+  defp needs_down?([{version, mod, hash} | migrations_on_file], complete_migrations, :no_change) when is_map(complete_migrations) do
+    if Map.get(complete_migrations, version) == hash do
+      needs_down?(migrations_on_file, complete_migrations, :no_change)
+    else
+      [{version, mod, ""}] ++ needs_down?(migrations_on_file, :needs_down)
+    end
+  end
+
+  defp needs_down?([], _, :no_change), do: []
+
+  defp needs_down?([{version, mod, hash} | migrations_on_file], :needs_down) do
+    [{version, mod, ""}] ++ needs_down?(migrations_on_file, :needs_down)
+  end
+
+  defp needs_down?([], :needs_down), do: []
+
+  defp collect_migrations(versions, migration_source, _opts = [smart: true]) do
+    versions_with_hash =
+      versions
+      |> Enum.map(&load_migration!/1)
+      |> Enum.map(&hash_migration_source/1)
+      |> Enum.map(fn {version, _, hash} -> {version, hash} end)
+      |> Enum.into(%{})
+
     ups_with_file =
       versions
+      |> Enum.map(fn [version | _] -> version end)
+      |> pending_in_direction(migration_source, :smart)
+      |> Enum.map(&load_migration!/1)
+      |> Enum.map(&hash_migration_source/1)
+      |> Enum.map(fn {version, name, hash} ->
+        {
+          if Map.get(versions_with_hash, version) == hash do
+            :up
+          else
+            :diff
+          end, version, name
+        }
+        end)
+
+    ups_without_file =
+      versions
+      |> Enum.map(fn [version | _] -> version end)
+      |> versions_without_file(migration_source)
+      |> Enum.map(fn version ->{:diff, version, "** FILE NOT FOUND **"} end)
+
+    downs =
+      versions
+      |> Enum.map(fn [version | _] -> version end)
+      |> pending_in_direction(migration_source, :up)
+      |> Enum.map(fn {version, name, _} -> {:down, version, name} end)
+
+    ups_with_file ++ ups_without_file ++ downs
+  end
+
+  defp collect_migrations(versions, migration_source, _opts) do
+    ups_with_file =
+      versions
+      |> Enum.map(fn [version | _] -> version end)
       |> pending_in_direction(migration_source, :down)
       |> Enum.map(fn {version, name, _} -> {:up, version, name} end)
 
     ups_without_file =
       versions
+      |> Enum.map(fn [version | _] -> version end)
       |> versions_without_file(migration_source)
       |> Enum.map(fn version -> {:up, version, "** FILE NOT FOUND **"} end)
 
     downs =
       versions
+      |> Enum.map(fn [version | _] -> version end)
       |> pending_in_direction(migration_source, :up)
       |> Enum.map(fn {version, name, _} -> {:down, version, name} end)
 
@@ -545,6 +651,13 @@ defmodule Ecto.Migrator do
     |> Enum.reverse
   end
 
+  defp pending_in_direction(versions, migration_source, :smart) do
+    migration_source
+    |> migrations_for()
+    |> Enum.filter(fn {version, _name, _file} -> version in versions end)
+    |> Enum.reverse
+  end
+
   defp migrations_for(migration_source) when is_list(migration_source) do
     migration_source
     |> Enum.flat_map(fn
@@ -582,11 +695,21 @@ defmodule Ecto.Migrator do
     end
   end
 
+  defp ensure_no_duplication!([{version, _} | t]) do
+    cond do
+      List.keyfind(t, version, 0) ->
+        raise Ecto.MigrationError, "migrations can't be executed, migration version #{version} is duplicated"
+
+      true ->
+        ensure_no_duplication!(t)
+    end
+  end
+
   defp ensure_no_duplication!([]), do: :ok
 
   defp load_migration!({version, _, mod}) when is_atom(mod) do
     if migration?(mod) do
-      {version, mod}
+      {version, mod, ""}
     else
       raise Ecto.MigrationError, "module #{inspect(mod)} is not an Ecto.Migration"
     end
@@ -596,14 +719,39 @@ defmodule Ecto.Migrator do
     loaded_modules = file |> Code.compile_file() |> Enum.map(&elem(&1, 0))
 
     if mod = Enum.find(loaded_modules, &migration?/1) do
-      {version, mod}
+      {version, mod, get_source(file, mod)}
     else
       raise Ecto.MigrationError, "file #{Path.relative_to_cwd(file)} does not define an Ecto.Migration"
     end
   end
 
+  defp load_migration!([version, migration_source]) do
+    loaded_modules = migration_source |> Code.compile_string() |> Enum.map(&elem(&1, 0))
+
+    if mod = Enum.find(loaded_modules, &migration?/1) do
+      {version, mod, migration_source}
+    else
+      raise Ecto.MigrationError, "database migration version #{version} does not define an Ecto.Migration"
+    end
+  end
+
+  defp get_source(file, mod) do
+    if mod = down?(mod) do
+      case File.read(file) do
+        {:ok, migration_script} -> migration_script
+        _ -> raise Ecto.MigrationError, "file #{Path.relative_to_cwd(file)} could not be read"
+      end
+    else
+      ""
+    end
+  end
+
   defp migration?(mod) do
     function_exported?(mod, :__migration__, 0)
+  end
+
+  defp down?(mod) do
+    function_exported?(mod, :down, 0)
   end
 
   defp migrate([], direction, _repo, opts) do
@@ -613,24 +761,30 @@ defmodule Ecto.Migrator do
   end
 
   defp migrate(migrations, direction, repo, opts) do
-    for {version, mod} <- migrations,
-        do_direction(direction, repo, version, mod, opts),
+    for {version, mod, migration_script} <- migrations,
+        do_direction(direction, repo, version, migration_script, mod, opts),
         do: version
   end
 
-  defp do_direction(:up, repo, version, mod, opts) do
+  defp do_direction(:up, repo, version, migration_script, mod, opts) do
     conditional_lock_for_migrations mod, version, repo, opts, fn config, versions ->
       unless version in versions do
-        do_up(repo, config, version, mod, opts)
+        do_up(repo, config, version, migration_script, mod, opts)
       end
     end
   end
 
-  defp do_direction(:down, repo, version, mod, opts) do
+  defp do_direction(:down, repo, version, migration_script, mod, opts) do
     conditional_lock_for_migrations mod, version, repo, opts, fn config, versions ->
       if version in versions do
-        do_down(repo, config, version, mod, opts)
+        do_down(repo, config, version, migration_script, mod, opts)
       end
+    end
+  end
+
+  defp do_direction(:smart_down, repo, version, migration_script, mod, opts) do
+    conditional_lock_for_migrations mod, version, repo, opts, fn config, versions ->
+      do_down(repo, config, version, migration_script, mod, opts)
     end
   end
 

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -213,6 +213,7 @@ defmodule Ecto.Migrator do
   @spec up(Ecto.Repo.t, integer, module, Keyword.t) :: :ok | :already_up
   def up(repo, version, module, opts \\ []) do
     conditional_lock_for_migrations module, version, repo, opts, fn config, versions ->
+      versions = versions |> Enum.map(&List.first(&1))
       if version in versions do
         :already_up
       else
@@ -271,6 +272,7 @@ defmodule Ecto.Migrator do
   @spec down(Ecto.Repo.t, integer, module) :: :ok | :already_down
   def down(repo, version, module, opts \\ []) do
     conditional_lock_for_migrations module, version, repo, opts, fn config, versions ->
+      versions = versions |> Enum.map(&List.first(&1))
       if version in versions do
         do_down(repo, config, version, "", module, opts)
       else
@@ -388,7 +390,7 @@ defmodule Ecto.Migrator do
       run_smart(repo, migration_source, opts)
     else
       #noop if not in dev or if user enters anything other than 'y'
-      output -> :ok
+      _ -> :ok
     end
   end
 
@@ -501,7 +503,7 @@ defmodule Ecto.Migrator do
 
   defp needs_down?([], _, :no_change), do: []
 
-  defp needs_down?([{version, mod, hash} | migrations_on_file], :needs_down) do
+  defp needs_down?([{version, mod, _} | migrations_on_file], :needs_down) do
     [{version, mod, ""}] ++ needs_down?(migrations_on_file, :needs_down)
   end
 
@@ -840,7 +842,7 @@ defmodule Ecto.Migrator do
   end
 
   defp do_direction(:smart_down, repo, version, migration_script, mod, opts) do
-    conditional_lock_for_migrations mod, version, repo, opts, fn config, versions ->
+    conditional_lock_for_migrations mod, version, repo, opts, fn config, _ ->
       do_down(repo, config, version, migration_script, mod, opts)
     end
   end

--- a/lib/ecto/migrator.ex
+++ b/lib/ecto/migrator.ex
@@ -740,7 +740,7 @@ defmodule Ecto.Migrator do
   end
 
   defp get_source(file, mod) do
-    if mod = down?(mod) do
+    if down?(mod) || change?(mod) do
       case File.read(file) do
         {:ok, migration_script} -> migration_script
         _ -> raise Ecto.MigrationError, "file #{Path.relative_to_cwd(file)} could not be read"
@@ -756,6 +756,10 @@ defmodule Ecto.Migrator do
 
   defp down?(mod) do
     function_exported?(mod, :down, 0)
+  end
+
+  defp change?(mod) do
+    function_exported?(mod, :change, 0)
   end
 
   defp migrate([], direction, _repo, opts) do

--- a/lib/mix/tasks/ecto.migrate.ex
+++ b/lib/mix/tasks/ecto.migrate.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     all: :boolean,
     step: :integer,
     to: :integer,
+    smart: :boolean,
     quiet: :boolean,
     prefix: :string,
     pool_size: :integer,
@@ -105,7 +106,7 @@ defmodule Mix.Tasks.Ecto.Migrate do
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
 
     opts =
-      if opts[:to] || opts[:step] || opts[:all],
+      if opts[:to] || opts[:step] || opts[:all] || opts[:smart],
         do: opts,
         else: Keyword.put(opts, :all, true)
 

--- a/lib/mix/tasks/ecto.migrations.ex
+++ b/lib/mix/tasks/ecto.migrations.ex
@@ -13,7 +13,8 @@ defmodule Mix.Tasks.Ecto.Migrations do
     repo: [:keep, :string],
     no_compile: :boolean,
     no_deps_check: :boolean,
-    migrations_path: :keep
+    migrations_path: :keep,
+    smart: :boolean
   ]
 
   @moduledoc """
@@ -53,7 +54,7 @@ defmodule Mix.Tasks.Ecto.Migrations do
   """
 
   @impl true
-  def run(args, migrations \\ &Ecto.Migrator.migrations/2, puts \\ &IO.puts/1) do
+  def run(args, migrations \\ &Ecto.Migrator.migrations/3, puts \\ &IO.puts/1) do
     repos = parse_repo(args)
     {opts, _} = OptionParser.parse! args, strict: @switches, aliases: @aliases
 
@@ -61,7 +62,7 @@ defmodule Mix.Tasks.Ecto.Migrations do
       ensure_repo(repo, args)
       paths = ensure_migrations_paths(repo, opts)
 
-      case Ecto.Migrator.with_repo(repo, &migrations.(&1, paths), [mode: :temporary]) do
+      case Ecto.Migrator.with_repo(repo, &migrations.(&1, paths, opts), [mode: :temporary]) do
         {:ok, repo_status, _} ->
           puts.(
             """

--- a/test/ecto/migrator_test.exs
+++ b/test/ecto/migrator_test.exs
@@ -272,7 +272,7 @@ defmodule Ecto.MigratorTest do
       :ok = up(TestRepo, 10, ChangeMigration, prefix: :custom)
     end)
 
-    assert [{10, :custom} | _] = MigrationsAgent.get()
+    assert [{10, "", :custom} | _] = MigrationsAgent.get()
 
     Process.put(:repo_default_options, [prefix: nil])
 
@@ -280,13 +280,13 @@ defmodule Ecto.MigratorTest do
       :ok = up(TestRepo, 11, ChangeMigration, prefix: :custom)
     end)
 
-    assert [{11, :custom} | _] = MigrationsAgent.get()
+    assert [{11, "", :custom} | _] = MigrationsAgent.get()
 
     capture_log(fn ->
       :already_up = up(TestRepo, 11, ChangeMigration, prefix: :custom)
     end)
 
-    assert [{11, :custom} | _] = MigrationsAgent.get()
+    assert [{11, "", :custom} | _] = MigrationsAgent.get()
   end
 
   test "logs migrations" do
@@ -452,7 +452,7 @@ defmodule Ecto.MigratorTest do
         assert_receive {:lock_for_migrations, _, _, []}
         refute_received {:lock_for_migrations, _, _, _}
 
-        assert match?({:create_if_not_exists, %_{name: :schema_migrations}, _}, last_command())
+        assert match?({:alter, %_{name: :schema_migrations}, _}, last_command())
       end
     end
   end

--- a/test/mix/tasks/ecto.migrations_test.exs
+++ b/test/mix/tasks/ecto.migrations_test.exs
@@ -38,7 +38,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
   test "displays the up and down status for the default repo" do
     Application.put_env(:ecto_sql, :ecto_repos, [Repo])
 
-    migrations = fn _, _ ->
+    migrations = fn _, _, _ ->
       [
         {:up,   0,              "up_migration_0"},
         {:up,   20160000000001, "up_migration_1"},
@@ -66,7 +66,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
   end
 
   test "migrations displays the up and down status for any given repo" do
-    migrations = fn _, _ ->
+    migrations = fn _, _, _ ->
       [
         {:up,   20160000000001, "up_migration_1"},
         {:down, 20160000000002, "down_migration_1"}
@@ -89,7 +89,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
   test "does not run from _build" do
     Application.put_env(:ecto_sql, :ecto_repos, [Repo])
 
-    migrations = fn repo, [path] ->
+    migrations = fn repo, [path], _ ->
       assert repo == Repo
       refute path =~ ~r/_build/
       []
@@ -105,7 +105,7 @@ defmodule Mix.Tasks.Ecto.MigrationsTest do
     File.mkdir_p!(path2)
 
     run ["-r", to_string(Repo), "--migrations-path", path1, "--migrations-path", path2],
-        fn Repo, [^path1, ^path2] -> [] end,
+        fn Repo, [^path1, ^path2], _ -> [] end,
         fn _ -> :ok end
   end
 end


### PR DESCRIPTION
Add column to schema_migrations table to store a string value of the migration script as ran.

Add ability to run migrations in "smart" (--smart flag) mode. This will check the diff of previously ran migrations in the schema_migrations table, and if different, run the stored downs up to and including the different one.